### PR TITLE
Fix missing dependency xdg-user-dirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ More Screenshots can be found in the [screenshots](screenshots/) folder.
 ## Prerequisites
 
 * git
+* xdg-user-dirs
 * ansible >= 2.7
 * When using arch: [ansible-aur module](https://github.com/kewlfft/ansible-aur), though it will be installed when using the playbook setup01-arch-prerequirements.yml
 * Disable your display manager. It can work, but I can not guarantee it because I do not use one

--- a/setup-01-arch-prerequirements.yml
+++ b/setup-01-arch-prerequirements.yml
@@ -20,6 +20,7 @@
           community.general.pacman:
             name:
               - git
+              - xdg-user-dirs
             state: present
           become: true
 


### PR DESCRIPTION
In my recent fresh installation of Arch Linux, I've found that `xdg-user-dirs` is not installed, which provides `xdg-user-dir` in the `setup-02-de.yml` .